### PR TITLE
all pivot's parameters are keyword only in pandas>=2.0

### DIFF
--- a/timedf_benchmarks/optiver_volatility/prepare_dataset.py
+++ b/timedf_benchmarks/optiver_volatility/prepare_dataset.py
@@ -382,7 +382,7 @@ def stock_id_embeddings(df2, pivot, df_pv):
         with tm.timeit("LDA train"):
             stock_id_emb = pd.DataFrame(
                 lda.fit_transform(pivot.transpose()),
-                index=df_pv.pivot("time_id", "stock_id", "vol").columns,
+                index=df_pv.pivot(index="time_id", columns="stock_id", values="vol").columns,
             )
 
         for i in range(lda_n):


### PR DESCRIPTION
https://github.com/intel-ai/modin-perf/actions/runs/5237044106/jobs/9455257288

```bash
index=df_pv.pivot("time_id", "stock_id", "vol").columns,
  File "/_work/modin/modin/logging/logger_decorator.py", line 128, in run_and_log
    return obj(*args, **kwargs)
TypeError: pivot() takes 1 positional argument but 4 were given
```